### PR TITLE
Blueprints update for GPM and repository support

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,6 +1,14 @@
 name: VideoEmbed
-version: 1.0.0
-description: Convert links to videos into embed video.
+version: 1.3.0
+description: The **VideoEmbed** plugin converts links to videos from popular sharing services to embed format. Supported: YouTube, Vimeo, Coub, Vine and planned more services.
+icon: video-camera
+author:
+  name: Maxim Hodyrev
+  email: your_email_here
+homepage: http://maximkou.github.io/grav-plugin-videoembed/
+keywords: videoembed, plugin, videos, services, youtube, vimeo, coub, vine
+bugs: https://github.com/maximkou/grav-plugin-videoembed/issues
+license: MIT
 
 form:
   fields:


### PR DESCRIPTION
Hey there,
we are close to release a new version of Grav which will include GPM (Grav Package Manager) and with it we are also revamping how our repository system works.
All plugins and themes releases will be now automatically picked up without the need for you to notify us. The GPM will allow users to get notified about new updates available, too.

Because of this change, a lot of details we were manually editing ourselves for the site are now part of the blueprints and will be used to present your plugin on our site.

I have edited blueprints of your plugin based on the details you originally gave us and to match the new requirements. You are free to ignore this PR and just edit it yourself. I left blank the email on purpose so you can fill it with your preferred one (it is a required field).

Note that if a blueprints fail to match some of the requirements, the plugin will be unpublished from the website until a new version with the fixed blueprints will be available.

Also please note that our current [develop](https://github.com/getgrav/grav) branch had major changes that are still in the works. I would suggest not to release a new version of your plugin just for the blueprints, yet. Other changes might be needed for your plugin in order to work with the upcoming version of Grav.

Thank you!

More details:
- [Blueprints documentation](https://github.com/getgrav/grav-learn/blob/feature/learn-gpm/pages/05.advanced/01.blueprints/docs.md)
- [Blueprint Example](https://github.com/getgrav/grav-plugin-breadcrumbs/blob/develop/blueprints.yaml#L1-13)
- [GPM documentation](https://github.com/getgrav/grav-learn/blob/feature/learn-gpm/pages/05.advanced/06.grav-gpm/docs.md)
