### PR TITLE
Added more flexbility for enable/disable per-page

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All services configuration located in `services` section of `videoembed.yaml`.
 **Available options:**
 
 * *enabled*: disable/enable some service support.
+* *all_pages*: disable/enable processing on all pages by deafult
 * *assets*: add service-specific assets(`js`, `css`) into page `<HEAD>` block. Assets will be added, if service support enabled and if least one link to service was replaced.
 * *embed_html_attr*: html attributes for embed element(iframe/video), e.g. `width: 0` will create `<iframe width="0">...</iframe>`
 * *embed_options*: video options, e.g. autoplay (not available for self-hosted videos(`VideoJS`))
@@ -98,6 +99,18 @@ All services configuration located in `services` section of `videoembed.yaml`.
 
 You can see default services configuration in [videoembed.yaml](https://github.com/maximkou/grav-plugin-videoembed/blob/development/videoembed.yaml#L9) file.
 
+## Enabling and Disabling
+
+If you have **all_pages** option in your configuration set to `true` you can disable `videoembed` on a specific page by adding the following in your page header:
+
+```
+---
+# ... more headers
+videoembed: false
+---
+```
+
+If you have **all_pages** option in your configuration set to `false` you can enable on a specific page by either providing a `true` value or customization parameters for the `videoembed` option.
 
 ## Customizing single video/page videos parameters
 If you need set custom plugin parameters for single page, set plugin parameters in page header in section `videoembed`, e.g:

--- a/videoembed.yaml
+++ b/videoembed.yaml
@@ -1,5 +1,5 @@
 enabled: true
-
+all_pages: true
 responsive: false
 container:
     element: div


### PR DESCRIPTION
We are using your plugin on our `learn.getgrav.org` site and noticed it was causing problems on some pages. We started digging into your plugin a little and noticed that it processed on every page even though we only needed it on one.  I have added the ability to set `all_pages: false` and then just enable on pages with `videoembed: true` or `videoembed: { .. options .. }`.  Also if you set `all_pages: true` you can disable on a specific page by setting `videoembed: false`.  

I have not dug further to find out what exactly was causing the issue, but just having these options makes it perform better and with more control than before.
